### PR TITLE
Remove width from columns container

### DIFF
--- a/_columns.scss
+++ b/_columns.scss
@@ -74,7 +74,6 @@ $guss-columns-fallback-columns: 3 !default;
     } @else {
         #{$base-class} {
             @include rem((
-                width: $columns-fallback-width + $column-gap,
                 margin-left: $column-gap / 2 * -1,
                 margin-right: $column-gap / 2 * -1
             ));


### PR DESCRIPTION
For non-column browsers, width was spurious
## Before

![guss-naughty](https://f.cloud.github.com/assets/74132/2159245/32ed2766-94a1-11e3-90b2-30e4c540b0d6.jpg)
## After

![guss-good-boy](https://f.cloud.github.com/assets/74132/2159246/378af1c2-94a1-11e3-9d86-5fc1d4b47843.jpg)
