### PR TITLE
Add alternative mobile layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 (2014-02-24)
+
+- Invoke mobile layout variations using `l-row--layout-m`
+
 ## 1.0.5 (2014-02-20)
 
 - Fix a bug in IE9 where hovering a link in a column would change the position of the surrounding elements

--- a/_row.scss
+++ b/_row.scss
@@ -75,6 +75,37 @@ $guss-row-fallback-width: 940px !default;
             #{$base-class}__item--boost-1 { @include flex-grow(1.5); }
             #{$base-class}__item--boost-2 { @include flex-grow(2); }
         }
+
+        // Mobile layout variation:
+        // - Items are aligned horizontally, 50% each
+        // - Should degrade into a vertical list
+        //
+        // Browser support:
+        // - iOS 7+ (-webkit- prefix required)
+        // - Chrome
+        // - IE 11+
+        // - Firefox 28+ (for flex-wrap support)
+        @include mq($to: tablet) {
+            #{$base-class}--layout-m {
+                display: -webkit-flex;
+                display: flex;
+                -webkit-flex-wrap: wrap;
+                flex-wrap: wrap;
+
+                // Items fill half the width of their container
+                #{$base-class}__item {
+                    -webkit-flex-basis: 50%;
+                    flex-basis: 50%;
+                }
+
+                // Break the flow on mobile:
+                // Item will fill the whole width of its container
+                #{$base-class}__item--break-m {
+                    -webkit-flex: 1 100%;
+                    flex: 1 100%;
+                }
+            }
+        }
     } @else {
         #{$base-class} {
             width: $guss-row-fallback-width;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "guss-layout",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "main": [
     "_row.scss",
     "_columns.scss"


### PR DESCRIPTION
See the [updated test page](http://sassmeister.com/gist/7986076).
## What?

Use `l-row--layout-m` to activate flex box on mobile:
- Items fill half the width of their container
- Break the flow and have an item fill the whole width of its container with `l-row__item--break-m`
## How?

![screen shot 2014-02-25 at 10 08 51](https://f.cloud.github.com/assets/85783/2256297/e91aca40-9e04-11e3-8623-186dad69ed4e.PNG)

``` html
    <div class="l-row l-row--items-4 l-row--layout-m">
        <div class="l-row__item">1</div>
        <div class="l-row__item">2</div>
        <div class="l-row__item">3</div>
        <div class="l-row__item">4</div>
    </div>
```
# 

![screen shot 2014-02-25 at 10 08 57](https://f.cloud.github.com/assets/85783/2256301/ff34ef18-9e04-11e3-99d1-13980af7de06.PNG)

``` html
    <div class="l-row l-row--items-4 l-row--layout-m">
        <div class="l-row__item l-row__item--break-m">1</div>
        <div class="l-row__item">2</div>
        <div class="l-row__item">3</div>
    </div>
```
### Browser support:

Mobile layout variations should degrade gracefully into a vertical list*
- iOS 7+ (-webkit prefix needed)
- Chrome
- IE 11+
- Firefox 28+ (supports flex-wrap: wrap)

\* Firefox < 28 treats mobile layouts as if it were horizontal lists (instead of breaking the items on multiple rows). Why is it fine? Because it will only affect users who don't update their Firefox app on Android. Also, Firefox < 28 desktop users who view the site at mobile breakpoint should represent a small portion of our entire user base.

![ ](http://media.giphy.com/media/PPp293NzJ0A5a/giphy.gif)
