### PR TITLE
Removed dependency on rem

### DIFF
--- a/_columns.scss
+++ b/_columns.scss
@@ -126,29 +126,27 @@ $guss-columns-fallback-columns: 3 !default;
             @if function-exists(rem) {
                 -webkit-column-width: rem($column-min-width);
                 -webkit-column-gap: rem($column-gap);
-                -webkit-column-fill: balance;
 
                 -moz-column-width: rem($column-min-width);
                 -moz-column-gap: rem($column-gap);
-                -moz-column-fill: balance;
 
                 column-width: rem($column-min-width);
                 column-gap: rem($column-gap);
-                column-fill: balance;
             }
             @else {
                 -webkit-column-width: $column-min-width;
                 -webkit-column-gap: $column-gap;
-                -webkit-column-fill: balance;
 
                 -moz-column-width: $column-min-width;
                 -moz-column-gap: $column-gap;
-                -moz-column-fill: balance;
 
                 column-width: $column-min-width;
                 column-gap: $column-gap;
-                column-fill: balance;
             }
+
+            -webkit-column-fill: balance;
+            -moz-column-fill: balance;
+            column-fill: balance;
         }
         #{$base-class}__item {
             // Fix a bug in IE where hovering items would change

--- a/_columns.scss
+++ b/_columns.scss
@@ -123,17 +123,32 @@ $guss-columns-fallback-columns: 3 !default;
                     $css3-columns-support: $browser-supports-columns) {
     @if $css3-columns-support {
         #{$base-class} {
-            -webkit-column-width: rem($column-min-width);
-            -webkit-column-gap: rem($column-gap);
-            -webkit-column-fill: balance;
+            @if function-exists(rem) {
+                -webkit-column-width: rem($column-min-width);
+                -webkit-column-gap: rem($column-gap);
+                -webkit-column-fill: balance;
 
-            -moz-column-width: rem($column-min-width);
-            -moz-column-gap: rem($column-gap);
-            -moz-column-fill: balance;
+                -moz-column-width: rem($column-min-width);
+                -moz-column-gap: rem($column-gap);
+                -moz-column-fill: balance;
 
-            column-width: rem($column-min-width);
-            column-gap: rem($column-gap);
-            column-fill: balance;
+                column-width: rem($column-min-width);
+                column-gap: rem($column-gap);
+                column-fill: balance;
+            }
+            @else {
+                -webkit-column-width: $column-min-width;
+                -webkit-column-gap: $column-gap;
+                -webkit-column-fill: balance;
+
+                -moz-column-width: $column-min-width;
+                -moz-column-gap: $column-gap;
+                -moz-column-fill: balance;
+
+                column-width: $column-min-width;
+                column-gap: $column-gap;
+                column-fill: balance;
+            }
         }
         #{$base-class}__item {
             // Fix a bug in IE where hovering items would change


### PR DESCRIPTION
theguardian.com is using grunt for px to rem conversion so this update is making using rem optional.
